### PR TITLE
Add production domain to Supabase auth redirect URLs

### DIFF
--- a/supabase/auth/config.json
+++ b/supabase/auth/config.json
@@ -1,6 +1,7 @@
 {
   "site_url": "http://localhost:3000",
   "additional_redirect_urls": [
+    "https://applications-tracker.vercel.app",
     "https://planning-tracker.vercel.app",
     "https://staging-planning-tracker.vercel.app"
   ],


### PR DESCRIPTION
## Summary
- add the applications-tracker production domain to the Supabase auth configuration so magic links can redirect correctly

## Testing
- not run (Supabase CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d7c3bd97e8832f90a2c10d6cb483b1